### PR TITLE
Fix page creation to be compatible with BoneLib 3.1.0+

### DIFF
--- a/BoneMenu/MassesBoneMenu.cs
+++ b/BoneMenu/MassesBoneMenu.cs
@@ -11,7 +11,7 @@ namespace AvatarStatsLoader.BoneMenu
 
         public static void Init()
         {
-            menu = Menu.CreatePage("Avatar Mass", Color.white, 7);
+            menu = Page.Root.CreatePage("Avatar Mass", Color.white, 7);
             massChest = new EntryMenu(menu, "Chest Mass", () => AvatarStatsMod.currentAvatar.GetLoadMassChest(), AvatarStatsMod.massChest);
             massPelvis = new EntryMenu(menu, "Pelvis Mass", () => AvatarStatsMod.currentAvatar.GetLoadMassPelvis(), AvatarStatsMod.massPelvis);
             massHead = new EntryMenu(menu, "Head Mass", () => AvatarStatsMod.currentAvatar.GetLoadMassHead(), AvatarStatsMod.massHead);

--- a/BoneMenu/StatsBoneMenu.cs
+++ b/BoneMenu/StatsBoneMenu.cs
@@ -11,7 +11,7 @@ namespace AvatarStatsLoader.BoneMenu
 
         public static void Init()
         {
-            menu = Menu.CreatePage("Avatar Stats", Color.white, 7);
+            menu = Page.Root.CreatePage("Avatar Stats", Color.white, 7);
             agility = new EntryMenu(menu, "Agility", () => AvatarStatsMod.currentAvatar.GetLoadAgility(), AvatarStatsMod.agility);
             strengthUpper = new EntryMenu(menu, "Strength Upper", () => AvatarStatsMod.currentAvatar.GetLoadStrengthUpper(), AvatarStatsMod.strengthUpper);
             strengthLower = new EntryMenu(menu, "Strength Lower", () => AvatarStatsMod.currentAvatar.GetLoadStrengthLower(), AvatarStatsMod.strengthLower);


### PR DESCRIPTION
After creating #8, I decided to do a little digging into BoneLib and these errors in hopes of solving them, and then I found Page.Root.CreatePage! Builds and runs with the latest BoneLib on Bonelab patch 5 with MelonLoader v0.6.4 perfectly fine!

### Changes
- Changed Menu.CreatePage to Page.Root.CreatePage to fix compatibility with BoneLib 3.1.0+