### PR TITLE
Fix BoneMenu Error

### DIFF
--- a/AvatarStatsMod.cs
+++ b/AvatarStatsMod.cs
@@ -126,10 +126,7 @@ namespace AvatarStatsLoader
                 }
             });
             mpCat.SaveToFile(true);
-        }
 
-        public override void OnLateInitializeMelon()
-        {
             Type bonelibType = typeof(BoneLib.BuildInfo);
             FieldInfo versionField = bonelibType.GetField("Version");
             bool versionParsed = Version.TryParse(versionField.GetRawConstantValue() as string, out Version boneLibVersion);


### PR DESCRIPTION
Following the v1.3.3 version, when setting up BoneMenu the mod always throws a `System.MissingFieldException: Field not found: 'BoneLib.BoneMenu.Page.Root'` error. To fix this, surprisingly the methods responsible for checking BoneLib version in `OnLateInitializeMelon` had to be moved to `OnInitializeMelon` which fixed the issue